### PR TITLE
Use IBitstampCommunicator.Name in the log message prefix if available

### DIFF
--- a/src/Bitstamp.Client.Websocket/Client/BitstampWebsocketClient.cs
+++ b/src/Bitstamp.Client.Websocket/Client/BitstampWebsocketClient.cs
@@ -86,7 +86,7 @@ namespace Bitstamp.Client.Websocket.Client
 
         private string L(string msg)
         {
-            return $"[BITSTAMP WEBSOCKET CLIENT] {msg}";
+            return $"[{_communicator.Name ?? "BITSTAMP"} WEBSOCKET CLIENT] {msg}";
         }
 
         private void HandleMessage(ResponseMessage message)


### PR DESCRIPTION
Fixes #10 